### PR TITLE
Add delegate naming convention for event handlers

### DIFF
--- a/docs/Coding_Standards.md
+++ b/docs/Coding_Standards.md
@@ -38,6 +38,8 @@ Naming conventions are enforced by `.editorconfig` rules. However, understand th
 - **Fields (private/internal)**: `_camelCase` with leading underscore (e.g., `_aiClient`).
 - **Local variables and parameters**: `camelCase`.
 - **Interfaces**: Start with `I` (e.g., `IAiClient`).
+- **Delegates for event handlers**: `{EventName}Handler` (e.g., `AiCallPendingHandler`).
+
 
 ### Async Methods
 


### PR DESCRIPTION
## Summary

Adds clarification to the naming conventions section for delegates used as event handlers, establishing a clear pattern that improves code consistency and aligns with standard .NET conventions.

| File                      | Changes                                                                    |
| ------------------------- | -------------------------------------------------------------------------- |
| docs/Coding_Standards.md  | Add new naming convention entry: `{EventName}Handler` (e.g., `AiCallPendingHandler`) |